### PR TITLE
fix  error: 'function' is not a member of 'std' with newer compiler

### DIFF
--- a/src/utils.hxx
+++ b/src/utils.hxx
@@ -6,6 +6,7 @@
 #define CONVERTER_UTILS_HXX
 
 #include <memory>
+#include <functional>
 
 // May get deleted in the future, depending on future needs.
 


### PR DESCRIPTION
tmp/potoo/src/utils.hxx:13:52: note: 'std::function' is defined in header '<functional>'; did you forget to '#include <functional>'? /tmp/potoo/src/utils.hxx:9:1:
+#include <functional>